### PR TITLE
DynamicTableRenderPolicy的render方法中，直接新建一个包含一行一列的空白table，然后传给用户自定义render

### DIFF
--- a/src/main/java/com/deepoove/poi/policy/DynamicTableRenderPolicy.java
+++ b/src/main/java/com/deepoove/poi/policy/DynamicTableRenderPolicy.java
@@ -42,14 +42,12 @@ public abstract class DynamicTableRenderPolicy implements RenderPolicy {
 		XWPFRun run = runTemplate.getRun();
 		run.setText("", 0);
 		try {
-		    //w:tbl-w:tr-w:tc-w:p-w:tr
-			XmlCursor newCursor = ((XWPFParagraph)run.getParent()).getCTP().newCursor();
-			newCursor.toParent();
-			//if (newCursor.getObject() instanceof CTTc) 
-			newCursor.toParent();
-			newCursor.toParent();
-			XmlObject object = newCursor.getObject();
-			XWPFTable table = doc.getTable((CTTbl) object);
+			         XWPFTable table = doc.createTable(1, 1);//创建table
+			          table.removeRow(0);//去掉第一行空白的
+//			           table.setColumnWidth(0, 6 * 256);//设置列的宽度
+//			             table.setColumnWidth(1, 10 * 256);
+//			            table.setColumnWidth(2, 6 * 256);
+//			           table.setColumnWidth(3, 10 * 256);
 			render(table, data);
 		} catch (Exception e) {
 			logger.error("dynamic table error:" + e.getMessage(), e);

--- a/src/main/java/com/deepoove/poi/policy/DynamicTableRenderPolicy.java
+++ b/src/main/java/com/deepoove/poi/policy/DynamicTableRenderPolicy.java
@@ -29,25 +29,22 @@ import com.deepoove.poi.template.run.RunTemplate;
 
 /**
  * 支持表格内的文本模板动态持有XWPFTable对象
+ * 
  * @author Sayi 卅一
  * @version 0.0.3
  */
 public abstract class DynamicTableRenderPolicy implements RenderPolicy {
 
 	@Override
-	public void render(ElementTemplate eleTemplate, Object data,
-			XWPFTemplate template) {
+	public void render(ElementTemplate eleTemplate, Object data, XWPFTemplate template) {
 		NiceXWPFDocument doc = template.getXWPFDocument();
 		RunTemplate runTemplate = (RunTemplate) eleTemplate;
 		XWPFRun run = runTemplate.getRun();
 		run.setText("", 0);
 		try {
-			         XWPFTable table = doc.createTable(1, 1);//创建table
-			          table.removeRow(0);//去掉第一行空白的
-//			           table.setColumnWidth(0, 6 * 256);//设置列的宽度
-//			             table.setColumnWidth(1, 10 * 256);
-//			            table.setColumnWidth(2, 6 * 256);
-//			           table.setColumnWidth(3, 10 * 256);
+			XWPFTable table = doc.createTable(1, 1);// 创建table
+			table.removeRow(0);// 去掉第一行空白的
+
 			render(table, data);
 		} catch (Exception e) {
 			logger.error("dynamic table error:" + e.getMessage(), e);
@@ -56,7 +53,7 @@ public abstract class DynamicTableRenderPolicy implements RenderPolicy {
 
 	/**
 	 * @param table 表格
-	 * @param data 数据
+	 * @param data  数据
 	 */
 	public abstract void render(XWPFTable table, Object data);
 


### PR DESCRIPTION
DynamicTableRenderPolicy的render方法中，直接新建一个包含一行一列的空白table，然后传给用户自定义render，给用户最大发挥自由度，避免以下错误：
````
ERROR com.deepoove.poi.policy.DynamicTableRenderPolicy.render(DynamicTableRenderPolicy.java:53) dynamic table error:org.openxmlformats.schemas.wordprocessingml.x2006.main.impl.DocumentDocumentImpl cannot be cast to org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTbl
java.lang.ClassCastException: org.openxmlformats.schemas.wordprocessingml.x2006.main.impl.DocumentDocumentImpl cannot be cast to org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTbl
	at com.deepoove.poi.policy.DynamicTableRenderPolicy.render(DynamicTableRenderPolicy.java:50)
````