### PR TITLE
表格minitable渲染支持图片

### DIFF
--- a/src/main/java/com/deepoove/poi/data/CellRenderData.java
+++ b/src/main/java/com/deepoove/poi/data/CellRenderData.java
@@ -25,7 +25,7 @@ import com.deepoove.poi.data.style.TableStyle;
  */
 public class CellRenderData {
 
-    protected TextRenderData renderData;
+    protected RenderData renderData;
 
     /**
      * 单元格级别的样式：背景色、单元格文字对齐方式
@@ -34,7 +34,7 @@ public class CellRenderData {
 
     public CellRenderData() {}
 
-    public CellRenderData(TextRenderData renderData) {
+    public CellRenderData(RenderData renderData) {
         this.renderData = renderData;
     }
 
@@ -43,7 +43,7 @@ public class CellRenderData {
         this.cellStyle = cellStyle;
     }
 
-    public TextRenderData getRenderData() {
+    public RenderData getRenderData() {
         return renderData;
     }
 

--- a/src/main/java/com/deepoove/poi/data/RowRenderData.java
+++ b/src/main/java/com/deepoove/poi/data/RowRenderData.java
@@ -56,10 +56,14 @@ public class RowRenderData implements RenderData {
         return new RowRenderData(null == cellData ? null : Arrays.asList(cellData), null);
     }
 
-    public RowRenderData(List<TextRenderData> rowData, String backgroundColor) {
+	public static RowRenderData build(RenderData... cellData) {
+		return new RowRenderData(null == cellData ? null : Arrays.asList(cellData),null);
+	}
+
+    public RowRenderData(List<? extends RenderData> rowData, String backgroundColor) {
         this.cellDatas = new ArrayList<CellRenderData>();
         if (null != rowData) {
-            for (TextRenderData data : rowData) {
+            for (RenderData data : rowData) {
                 this.cellDatas.add(new CellRenderData(data));
             }
         }

--- a/src/main/java/com/deepoove/poi/render/WhereDelegate.java
+++ b/src/main/java/com/deepoove/poi/render/WhereDelegate.java
@@ -59,7 +59,7 @@ public class WhereDelegate {
         PictureRenderPolicy.Helper.renderPicture(run, data);
     }
 
-    public void renderMiniTable(MiniTableRenderData data) {
+    public void renderMiniTable(MiniTableRenderData data) throws Exception {
         MiniTableRenderPolicy.Helper.renderMiniTable(run, data);
     }
 

--- a/src/test/java/com/deepoove/poi/tl/example/DetailTablePolicy.java
+++ b/src/test/java/com/deepoove/poi/tl/example/DetailTablePolicy.java
@@ -39,8 +39,13 @@ public class DetailTablePolicy extends DynamicTableRenderPolicy {
 
                 // 合并单元格
                 TableTools.mergeCellsHorizonal(table, laborsStartRow, 0, 3);
-                MiniTableRenderPolicy.Helper.renderRow(table, laborsStartRow, labors.get(i));
-            }
+				try {
+					// 渲染图片造成的io异常
+					MiniTableRenderPolicy.Helper.renderRow(table, laborsStartRow, labors.get(i));
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
         }
 
         List<RowRenderData> goods = detailData.getGoods();
@@ -49,8 +54,12 @@ public class DetailTablePolicy extends DynamicTableRenderPolicy {
             for (int i = 0; i < goods.size(); i++) {
                 XWPFTableRow insertNewTableRow = table.insertNewTableRow(goodsStartRow);
                 for (int j = 0; j < 7; j++) insertNewTableRow.createCell();
-                MiniTableRenderPolicy.Helper.renderRow(table, goodsStartRow, goods.get(i));
-            }
+				try {
+					MiniTableRenderPolicy.Helper.renderRow(table, goodsStartRow, goods.get(i));
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
         }
     }
 

--- a/src/test/java/com/deepoove/poi/tl/example/PaymentExample.java
+++ b/src/test/java/com/deepoove/poi/tl/example/PaymentExample.java
@@ -1,9 +1,12 @@
 package com.deepoove.poi.tl.example;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.util.Arrays;
 import java.util.List;
 
+import com.deepoove.poi.data.PictureRenderData;
 import org.junit.Before;
 import org.junit.Test;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STJc;
@@ -30,7 +33,7 @@ public class PaymentExample {
     TableStyle rowStyle = new TableStyle();
     
     @Before
-    public void init(){
+    public void init() throws FileNotFoundException {
         headTextStyle.setFontFamily("Hei");
         headTextStyle.setFontSize(9);
         headTextStyle.setColor("7F7F7F");
@@ -72,7 +75,9 @@ public class PaymentExample {
         RowRenderData good = RowRenderData.build("4", "墙纸", "书房+卧室", "1500", "/", "400", "1600");
         good.setRowStyle(rowStyle);
         List<RowRenderData> goods = Arrays.asList(good, good, good);
-        RowRenderData  labor = RowRenderData.build("油漆工", "2", "200", "400");
+        // 图片测试
+        RowRenderData  labor = RowRenderData.build(new TextRenderData("油漆工"), new TextRenderData("2"), new TextRenderData("200"), new PictureRenderData(100, 120, ".png",
+			new FileInputStream("src/test/resources/logo.png")));
         labor.setRowStyle(rowStyle);
         List<RowRenderData> labors = Arrays.asList(labor, labor, labor, labor);
         detailTable.setGoods(goods);


### PR DESCRIPTION
1.修改了CellRenderData 的属性renderData,使用了更加抽象的RenderData类
2.修改了RowRenderData.build,使其接受renderData
3.修改了MiniTableRenderPolicy.Helper.renderRow()中的renderCell()方法,使其可以插入图片
4.PaymentExample测试通过