### PR TITLE
[fix]使用StyleUtils.styleTable方法时，如果不设置tableStyle的width，会报空指针异常

### DIFF
--- a/poi-tl/src/main/java/com/deepoove/poi/util/StyleUtils.java
+++ b/poi-tl/src/main/java/com/deepoove/poi/util/StyleUtils.java
@@ -179,8 +179,9 @@ public final class StyleUtils {
      */
     public static void styleTable(XWPFTable table, TableStyle tableStyle) {
         if (null == table || null == tableStyle) return;
-
-        TableTools.setWidth(table, tableStyle.getWidth(), tableStyle.getColWidths());
+        if (null != tableStyle.getWidth()) {
+            TableTools.setWidth(table, tableStyle.getWidth(), tableStyle.getColWidths());
+        }
 
         TableTools.setBorder(table::setLeftBorder, tableStyle.getLeftBorder());
         TableTools.setBorder(table::setRightBorder, tableStyle.getRightBorder());


### PR DESCRIPTION
我本来想设置表格的边框以及内容居中，但是却报错空指针异常，经过调试排查发现，StyleUtils.styleTable()方法中，如果tableStyle的width参数为空，则TableTools.setWidth方法中就会出现问题，所以建议在使用StyleUtils.styleTable()方法的时候，对tableStyle.getWidth()进行判空，这样用户不必设置宽度参数，只需关注自己需要的参数即可~
![image](https://github.com/user-attachments/assets/6b08a252-73d2-448b-91ee-dbd1ad98c771)
