### PR TITLE
[fix] LoopColumnTableRenderPolicy generate corrupted word documents in case of empty or null data.

### DIFF
--- a/poi-tl/src/main/java/com/deepoove/poi/plugin/table/LoopColumnTableRenderPolicy.java
+++ b/poi-tl/src/main/java/com/deepoove/poi/plugin/table/LoopColumnTableRenderPolicy.java
@@ -52,7 +52,7 @@ import com.deepoove.poi.util.TableTools;
 
 /**
  * Hack for loop table column
- * 
+ *
  * @author Sayi
  */
 public class LoopColumnTableRenderPolicy implements RenderPolicy {
@@ -86,7 +86,7 @@ public class LoopColumnTableRenderPolicy implements RenderPolicy {
         try {
             if (!TableTools.isInsideTable(run)) {
                 throw new IllegalStateException(
-                        "The template tag " + runTemplate.getSource() + " must be inside a table");
+                    "The template tag " + runTemplate.getSource() + " must be inside a table");
             }
             XWPFTableCell tagCell = (XWPFTableCell) ((XWPFParagraph) run.getParent()).getBody();
             XWPFTable table = tagCell.getTableRow().getTable();
@@ -102,7 +102,7 @@ public class LoopColumnTableRenderPolicy implements RenderPolicy {
             }
 
             int rowSize = table.getRows().size();
-            if (null != data && data instanceof Iterable) {
+            if (null != data && data instanceof Iterable && ((Iterable<?>) data).iterator().hasNext()) {
                 int colWidth = processLoopColWidth(table, width, templateColIndex, data);
 
                 Iterator<?> iterator = ((Iterable<?>) data).iterator();
@@ -142,8 +142,8 @@ public class LoopColumnTableRenderPolicy implements RenderPolicy {
                     }
 
                     RenderDataCompute dataCompute = template.getConfig()
-                            .getRenderDataComputeFactory()
-                            .newCompute(EnvModel.of(root, EnvIterator.makeEnv(index++, hasNext)));
+                        .getRenderDataComputeFactory()
+                        .newCompute(EnvModel.of(root, EnvIterator.makeEnv(index++, hasNext)));
                     cells.forEach(cell -> {
                         List<MetaTemplate> templates = resolver.resolveBodyElements(cell.getBodyElements());
                         new DocumentProcessor(template, resolver, dataCompute).process(templates);


### PR DESCRIPTION
This pull request includes updates to the `LoopColumnTableRenderPolicy` class in the `poi-tl` library to enhance data validation and improve table rendering behavior during column looping. The changes ensure better handling of empty data and empty rows in tables.

Enhancements to data validation:

* [`poi-tl/src/main/java/com/deepoove/poi/plugin/table/LoopColumnTableRenderPolicy.java`](diffhunk://#diff-d4e7a0fbef04aa0046bac535d2308cf29c05a000e68d0ef66b8483039a9dc756L105-R105): Updated the condition to check if the `data` object is an `Iterable` and has elements before proceeding with column width processing. This prevents unnecessary operations when the data is empty.

Improved table rendering behavior:

* [`poi-tl/src/main/java/com/deepoove/poi/plugin/table/LoopColumnTableRenderPolicy.java`](diffhunk://#diff-d4e7a0fbef04aa0046bac535d2308cf29c05a000e68d0ef66b8483039a9dc756R162-R166): Added logic to remove rows from the table if they become empty after removing cells during column looping. This ensures the table remains clean and avoids rendering issues. **If not handled, in many cases, generated word documents are corrupted**